### PR TITLE
Fix CVEs: Update base image and dependencies for Java 17

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,12 +86,14 @@ RUN set -eux; \
     wget -O netty-common-4.1.118.Final.jar https://repo1.maven.org/maven2/io/netty/netty-common/4.1.118.Final/netty-common-4.1.118.Final.jar; \
     wget -O jetty-server-9.4.57.v20241219.jar https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/9.4.57.v20241219/jetty-server-9.4.57.v20241219.jar; \
     wget -O jetty-http-9.4.57.v20241219.jar https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.57.v20241219/jetty-http-9.4.57.v20241219.jar; \
+    wget -O jetty-io-9.4.57.v20241219.jar https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.4.57.v20241219/jetty-io-9.4.57.v20241219.jar; \
+    wget -O logback-core-1.5.13.jar https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.5.13/logback-core-1.5.13.jar; \
     # Remove old vulnerable versions (updated to match actual versions in 3.9.3) \
-    rm -f netty-handler-4.1.113.Final.jar netty-common-4.1.113.Final.jar jetty-server-9.4.56.v20240826.jar jetty-http-9.4.56.v20240826.jar; \
+    rm -f netty-handler-4.1.113.Final.jar netty-common-4.1.113.Final.jar jetty-server-9.4.56.v20240826.jar jetty-http-9.4.56.v20240826.jar jetty-io-9.4.56.v20240826.jar logback-core-1.2.13.jar; \
     chown -R "$ZOO_USER:$ZOO_USER" "/$DISTRO_NAME"
 
 # layer2 which uses the base image which has 0 CVEs and copies zk from earlier layer
-FROM ghcr.io/nirmata/wolfi-openjdk-17-jre:0.20
+FROM ghcr.io/nirmata/wolfi-openjdk-17-jre:0.22
 
 ARG SHORT_DISTRO_NAME=zookeeper-3.9.3
 ARG DISTRO_NAME=apache-zookeeper-3.9.3-bin


### PR DESCRIPTION
CVE Fixes:
✅ CVE-2025-21587 & CVE-2025-30698 (Java 17.0.14 → 17.0.15): Updated base image from 0.20 to 0.22 ✅ CVE-2024-12798 & CVE-2024-12801 (logback-core 1.2.13 → 1.5.13): Updated dependency ✅ CVE-2024-6763 (jetty-io 9.4.56.v20240826 → 9.4.57.v20241219): Updated dependency

Changes:
- Dockerfile: Updated base image from ghcr.io/nirmata/wolfi-openjdk-17-jre:0.20 to 0.22
- Dockerfile: Added logback-core-1.5.13.jar download to fix logback CVEs
- Dockerfile: Added jetty-io-9.4.57.v20241219.jar download to fix jetty CVE
- Dockerfile: Updated removal of old vulnerable versions

Build tested and successful.
Maintaining Java 17 compatibility as requested.
All CVEs in scan results have been addressed with appropriate version updates.