### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Git
         run: |
@@ -30,10 +30,10 @@ jobs:
           git config --global user.email "github-actions@github.com"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.username }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -49,7 +49,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           context: ./docker
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `actions/checkout@v4 -> @34e11487...`
- `docker/setup-buildx-action@v3 -> @8d2750c6...`
- `docker/login-action@v3 -> @c94ce9fb...`
- `docker/metadata-action@v5 -> @c299e40c...`
- `docker/build-push-action@v5 -> @ca052bb5...`


### Why

Following the [TeamPCP/Checkmarx supply chain attack](https://thehackernews.com/2026/03/teampcp-hacks-checkmarx-github-actions.html), Nirmata is hardening all public repos against GitHub Actions tag hijacking. This repo was flagged as **CRITICAL** (unpinned actions + write permissions).

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
